### PR TITLE
Move the dialog for hard drive encryption password

### DIFF
--- a/pack_1/colorful_loop/colorful_loop.script
+++ b/pack_1/colorful_loop/colorful_loop.script
@@ -41,7 +41,7 @@ fun dialog_setup()
     
     box.sprite = Sprite(box.image);
     box.x = Window.GetX() + Window.GetWidth()  / 2 - box.image.GetWidth ()/2;
-    box.y = Window.GetY() + Window.GetHeight() / 2 - box.image.GetHeight()/2;
+    box.y = Window.GetY() + Window.GetHeight() / 1.3 - box.image.GetHeight()/2;
     box.z = 10000;
     box.sprite.SetPosition(box.x, box.y, box.z);
     


### PR DESCRIPTION
Move the password dialog down by the Y-axis so it doesn't overlap with the animation. Might help for the rest of the themes as well but I've only tried this one.