### PR TITLE
Fix off-center graphic on multi-monitor setups

### DIFF
--- a/pack_1/abstract_ring/abstract_ring.script
+++ b/pack_1/abstract_ring/abstract_ring.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 41; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/abstract_ring_alt/abstract_ring_alt.script
+++ b/pack_1/abstract_ring_alt/abstract_ring_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 76; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/alienware/alienware.script
+++ b/pack_1/alienware/alienware.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 24; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/angular/angular.script
+++ b/pack_1/angular/angular.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 30; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/angular_alt/angular_alt.script
+++ b/pack_1/angular_alt/angular_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 61; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/black_hud/black_hud.script
+++ b/pack_1/black_hud/black_hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 164; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 progress = 0;
 
 fun refresh_callback ()

--- a/pack_1/blockchain/blockchain.script
+++ b/pack_1/blockchain/blockchain.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 68; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/circle/circle.script
+++ b/pack_1/circle/circle.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 101; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/circle_alt/circle_alt.script
+++ b/pack_1/circle_alt/circle_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 48; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/circle_flow/circle_flow.script
+++ b/pack_1/circle_flow/circle_flow.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 72; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/circle_hud/circle_hud.script
+++ b/pack_1/circle_hud/circle_hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 156; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/circuit/circuit.script
+++ b/pack_1/circuit/circuit.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 96; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/colorful/colorful.script
+++ b/pack_1/colorful/colorful.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 375; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/colorful_loop/colorful_loop.script
+++ b/pack_1/colorful_loop/colorful_loop.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 89; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/colorful_sliced/colorful_sliced.script
+++ b/pack_1/colorful_sliced/colorful_sliced.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 120; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/connect/connect.script
+++ b/pack_1/connect/connect.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 120; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/cross_hud/cross_hud.script
+++ b/pack_1/cross_hud/cross_hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 210; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/cubes/cubes.script
+++ b/pack_1/cubes/cubes.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 81; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/cuts/cuts.script
+++ b/pack_1/cuts/cuts.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 62; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_1/cuts_alt/cuts_alt.script
+++ b/pack_1/cuts_alt/cuts_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 41; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/cyanide/cyanide.script
+++ b/pack_2/cyanide/cyanide.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 24; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/cybernetic/cybernetic.script
+++ b/pack_2/cybernetic/cybernetic.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 201; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/dark_planet/dark_planet.script
+++ b/pack_2/dark_planet/dark_planet.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 160; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/darth_vader/darth_vader.script
+++ b/pack_2/darth_vader/darth_vader.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 115; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/deus_ex/deus_ex.script
+++ b/pack_2/deus_ex/deus_ex.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 375; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/dna/dna.script
+++ b/pack_2/dna/dna.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 26; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/double/double.script
+++ b/pack_2/double/double.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 40; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/dragon/dragon.script
+++ b/pack_2/dragon/dragon.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 94; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/flame/flame.script
+++ b/pack_2/flame/flame.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 25; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/glitch/glitch.script
+++ b/pack_2/glitch/glitch.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 33; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/glowing/glowing.script
+++ b/pack_2/glowing/glowing.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 38; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/green_blocks/green_blocks.script
+++ b/pack_2/green_blocks/green_blocks.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 125; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/green_loader/green_loader.script
+++ b/pack_2/green_loader/green_loader.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 40; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon/hexagon.script
+++ b/pack_2/hexagon/hexagon.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 16; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_2/hexagon_2.script
+++ b/pack_2/hexagon_2/hexagon_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 100; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_alt/hexagon_alt.script
+++ b/pack_2/hexagon_alt/hexagon_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 119; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_dots/hexagon_dots.script
+++ b/pack_2/hexagon_dots/hexagon_dots.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 32; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_dots_alt/hexagon_dots_alt.script
+++ b/pack_2/hexagon_dots_alt/hexagon_dots_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 130; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_hud/hexagon_hud.script
+++ b/pack_2/hexagon_hud/hexagon_hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 205; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_2/hexagon_red/hexagon_red.script
+++ b/pack_2/hexagon_red/hexagon_red.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 75; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/hexa_retro/hexa_retro.script
+++ b/pack_3/hexa_retro/hexa_retro.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 90; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/hud/hud.script
+++ b/pack_3/hud/hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 20; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/hud_2/hud_2.script
+++ b/pack_3/hud_2/hud_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 40; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/hud_3/hud_3.script
+++ b/pack_3/hud_3/hud_3.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 125; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/hud_space/hud_space.script
+++ b/pack_3/hud_space/hud_space.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 119; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/ibm/ibm.script
+++ b/pack_3/ibm/ibm.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 48; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/infinite_seal/infinite_seal.script
+++ b/pack_3/infinite_seal/infinite_seal.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 540; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/ironman/ironman.script
+++ b/pack_3/ironman/ironman.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 100; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/liquid/liquid.script
+++ b/pack_3/liquid/liquid.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 19; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/loader/loader.script
+++ b/pack_3/loader/loader.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 105; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/loader_2/loader_2.script
+++ b/pack_3/loader_2/loader_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 50; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/loader_alt/loader_alt.script
+++ b/pack_3/loader_alt/loader_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 87; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/lone/lone.script
+++ b/pack_3/lone/lone.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 64; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/metal_ball/metal_ball.script
+++ b/pack_3/metal_ball/metal_ball.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 100; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/motion/motion.script
+++ b/pack_3/motion/motion.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 60; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/optimus/optimus.script
+++ b/pack_3/optimus/optimus.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 163; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/owl/owl.script
+++ b/pack_3/owl/owl.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 151; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/pie/pie.script
+++ b/pack_3/pie/pie.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 120; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/pixels/pixels.script
+++ b/pack_3/pixels/pixels.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 240; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_3/polaroid/polaroid.script
+++ b/pack_3/polaroid/polaroid.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 392; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/red_loader/red_loader.script
+++ b/pack_4/red_loader/red_loader.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 53; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/rings/rings.script
+++ b/pack_4/rings/rings.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 220; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/rings_2/rings_2.script
+++ b/pack_4/rings_2/rings_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 270; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/rog/rog.script
+++ b/pack_4/rog/rog.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 75; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/rog_2/rog_2.script
+++ b/pack_4/rog_2/rog_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 15; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/seal/seal.script
+++ b/pack_4/seal/seal.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 400; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/seal_2/seal_2.script
+++ b/pack_4/seal_2/seal_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 400; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/seal_3/seal_3.script
+++ b/pack_4/seal_3/seal_3.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 323; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/sliced/sliced.script
+++ b/pack_4/sliced/sliced.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 45; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/sphere/sphere.script
+++ b/pack_4/sphere/sphere.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 36; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/spin/spin.script
+++ b/pack_4/spin/spin.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 169; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/spinner_alt/spinner_alt.script
+++ b/pack_4/spinner_alt/spinner_alt.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 60; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/splash/splash.script
+++ b/pack_4/splash/splash.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 65; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/square/square.script
+++ b/pack_4/square/square.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 45; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/square_hud/square_hud.script
+++ b/pack_4/square_hud/square_hud.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 173; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/target/target.script
+++ b/pack_4/target/target.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 138; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/target_2/target_2.script
+++ b/pack_4/target_2/target_2.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 90; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/tech_a/tech_a.script
+++ b/pack_4/tech_a/tech_a.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 166; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/tech_b/tech_b.script
+++ b/pack_4/tech_b/tech_b.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 192; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/pack_4/unrap/unrap.script
+++ b/pack_4/unrap/unrap.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < 150; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 

--- a/template/template.script
+++ b/template/template.script
@@ -4,10 +4,10 @@
 ## Reddit : @adi1090x
 
 // Screen size
-screen.w = Window.GetWidth();
-screen.h = Window.GetHeight();
-screen.half.w = Window.GetWidth() / 2;
-screen.half.h = Window.GetHeight() / 2;
+screen.w = Window.GetWidth(0);
+screen.h = Window.GetHeight(0);
+screen.half.w = Window.GetWidth(0) / 2;
+screen.half.h = Window.GetHeight(0) / 2;
 
 // Question prompt
 question = null;
@@ -33,8 +33,8 @@ for (i = 0; i < NUM; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
+flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
 
 progress = 0;
 


### PR DESCRIPTION
…GetWidth(0) and Window.GetHeight(0).  This ensures consistent centering on every monitor for multimonitor setups, including those with disparate resolutions

On my multi-monitor setup the logo was off center.  Did some research and found this PR for a different Plymouth theme that had the same issue:

https://github.com/pop-os/plymouth-theme/pull/25/commits/fd7d3e31c6ddb4d705acc422f38b701894fa5cc1

Applied the fix to my copy of abstract_ring from your repo and verified that it fixed the issue.  Also verified that it still works properly on a single monitor setup (my laptop).

Thank you very much for creating these really nice Plymouth themes!

Cheers,
John