### PR TITLE
owl: Fix image centering

### DIFF
--- a/pack_3/owl/owl.script
+++ b/pack_3/owl/owl.script
@@ -33,8 +33,8 @@ for (i = 0; i < 151; i++)
 flyingman_sprite = Sprite();
 
 # set image position
-flyingman_sprite.SetX(Window.GetX() + (Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2)); # Place images in the center
-flyingman_sprite.SetY(Window.GetY() + (Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2));
+flyingman_sprite.SetX(Window.GetWidth(0) / 2 - flyingman_image[0].GetWidth() / 2); # Place images in the center
+flyingman_sprite.SetY(Window.GetHeight(0) / 2 - flyingman_image[0].GetHeight() / 2);
 
 progress = 0;
 


### PR DESCRIPTION
Apparently Window.GetX() and Window.GetY() sometimes give a value != 0, which offsets the images by an amount. It is also not necessary in the context, so I removed it and got correct results on multiple devices.